### PR TITLE
chore(release): 1.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@lagoni/asyncapi-quicktype-filter",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lagoni/asyncapi-quicktype-filter",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Library with qucktype filters for templates using AsyncAPI Generator",
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
Version bump in package.json and package-lock.json for release [1.2.1](https://github.com/jonaslagoni/asyncapi-quicktype-filter/releases/tag/v1.2.1)